### PR TITLE
Automate pre-build unit testing.

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -1,0 +1,12 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  range: 70...100
+  round: down
+  precision: 0
+  notify:
+    slack:
+      default:
+        url: "secret:LMdNZhR1RYwxNJBClcBX9lw/qxLONwSK2FmOYC1NInjo8HVLINvJUJ+K4Yu8wV5RBIVTH23fPs/gvqFm0qw3E6AU63899h38b6Itn0Z10u50119vRL/zJ8YKw4lk6eV0e07ZkPu6kfRJDS+KxE0X0YD/kjQ8aqHR3XMvKYZrnJM="

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,31 @@
 version: 2
 jobs:
-  build:
+
+  # pre-build stage
+  prebuild:
     docker:
       - image: circleci/clojure:lein-2.8.1
     steps:
       - checkout
-      - run: lein with-profile testing ancient
-      - run: lein with-profile testing bikeshed
-      - run: lein with-profile testing cljfmt check
-      - run: lein with-profile testing eastwood
-      - run: lein with-profile testing kibit
+
+      # static analysis
+      - run: lein with-profile prebuild ancient
+      - run: lein with-profile prebuild bikeshed
+      - run: lein with-profile prebuild cljfmt check
+      - run: lein with-profile prebuild eastwood
+      - run: lein with-profile prebuild kibit
+
+      # unit testing
+      - run: lein with-profile prebuild unit
+      - run: lein with-profile prebuild cloverage --fail-threshold 85 --codecov
+      - run:
+          command: bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
+          when: always
+
+workflows:
+  version: 2
+
+  # main pipeline
+  pipeline:
+    jobs:
+      - prebuild

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,11 @@
   :dependencies [[org.clojure/clojure "1.9.0"]]
   :main ^:skip-aot skein.core
   :target-path "target/%s"
+  :aliases {"unit" ["test"]}
   :profiles {:uberjar {:aot :all}
-             :testing {:plugins [[lein-ancient "0.6.15"]
+             :prebuild {:plugins [[lein-ancient "0.6.15"]
                                  [lein-bikeshed "0.5.1"]
                                  [lein-cljfmt "0.5.7"]
                                  [jonase/eastwood "0.2.5"]
-                                 [lein-kibit "0.1.6"]]}})
+                                 [lein-kibit "0.1.6"]
+                                 [lein-cloverage "1.0.10"]]}})

--- a/src/skein/core.clj
+++ b/src/skein/core.clj
@@ -5,4 +5,4 @@
 (defn -main
   "iThe main entry point for the Skein application."
   [& args]
-  (println "(Skein Core)"))
+  true)

--- a/test/skein/core_test.clj
+++ b/test/skein/core_test.clj
@@ -2,6 +2,6 @@
   (:require [clojure.test :refer :all]
             [skein.core :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(deftest canary-zero
+  (testing "skein core evaluates to true"
+    (is (true? (skein.core/-main)))))


### PR DESCRIPTION
This commit expands the CircleCI build automation configuration,
and adds Cloverage unit test coverage analysis, to the Skein
deployment pipeline.

Software-as-a-service components now include:

*   https://github.com/atomicsauce/skein
*   https://circleci.com/gh/atomicsauce/skein
*   https://codecov.io/gh/atomicsauce/skein

All three of the above tools are reporting out their respective
events to the Atomic Sauce Slack instance.

Instructions for pre-commit CLI invocation of all tools is now
documented at:

*   https://github.com/atomicsauce/skein/wiki/Before-you-commit

This should allow developers to confirm locally that things
are in good shape before commiting to the Github repository.

This commit corresponds to requirement 198 in the TargetProcess
tracking system.